### PR TITLE
Eager Loading User Data on Memberships

### DIFF
--- a/src/controllers/membership/getOne/getOneMembership.ts
+++ b/src/controllers/membership/getOne/getOneMembership.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { uuidValidation } from 'src/controllers/validation_utils';
+import { User } from 'src/models';
 
 export const getRequestedMembership = async (
   req: Request,
@@ -15,7 +16,14 @@ export const getRequestedMembership = async (
   }
 
   try {
-    const membership = (await project.getMemberships({ where: { id: membershipId } }))[0];
+    const membership = (
+      await project.getMemberships({
+        where: {
+          id: membershipId,
+        },
+        include: { model: User, as: 'user' },
+      })
+    )[0];
 
     if (!membership) {
       return res.notFoundError('requested membership not found');
@@ -29,36 +37,32 @@ export const getRequestedMembership = async (
 };
 
 const getOneMembership = async (req: Request, res: Response) => {
-  try {
-    const membership = req.requestedMembership;
-    const project = req.requestedProject;
-    const user = await membership.getUser();
+  const membership = req.requestedMembership;
+  const project = req.requestedProject;
+  const user = membership.user;
 
-    const membershipData = {
-      membership: {
-        id: membership.id,
-        project: {
-          id: project.id,
-          name: project.name,
-        },
-        user: {
-          username: user.username,
-          displayName: user.displayName,
-        },
-        isProjectAdmin: membership.isProjectAdmin,
-        isBlueprintManager: membership.isBlueprintManager,
-        isComponentManager: membership.isComponentManager,
-        isLayoutManager: membership.isLayoutManager,
-        isFragmentManager: membership.isFragmentManager,
-        createdOn: membership.createdOn,
-        updatedOn: membership.updatedOn,
+  const membershipData = {
+    membership: {
+      id: membership.id,
+      project: {
+        id: project.id,
+        name: project.name,
       },
-    };
+      user: {
+        username: user.username,
+        displayName: user.displayName,
+      },
+      isProjectAdmin: membership.isProjectAdmin,
+      isBlueprintManager: membership.isBlueprintManager,
+      isComponentManager: membership.isComponentManager,
+      isLayoutManager: membership.isLayoutManager,
+      isFragmentManager: membership.isFragmentManager,
+      createdOn: membership.createdOn,
+      updatedOn: membership.updatedOn,
+    },
+  };
 
-    res.success('membership has been successfully retrieved', membershipData);
-  } catch (error) {
-    res.fatalError('fatal error while getting membership');
-  }
+  res.success('membership has been successfully retrieved', membershipData);
 };
 
 export default getOneMembership;

--- a/src/controllers/membership/remove/removeMembership.ts
+++ b/src/controllers/membership/remove/removeMembership.ts
@@ -4,6 +4,7 @@ import removeMembershipValidation from './removeMembershipValidation';
 const removeMembership = async (req: Request, res: Response) => {
   const membership = req.requestedMembership;
   const project = req.requestedProject;
+  const user = membership.user;
   const confirm = req.body.confirm;
 
   const validationError = removeMembershipValidation(confirm);
@@ -12,7 +13,6 @@ const removeMembership = async (req: Request, res: Response) => {
   }
 
   try {
-    const user = await membership.getUser();
     await membership.destroy();
 
     const membershipData = {

--- a/src/controllers/membership/update/updateMembership.ts
+++ b/src/controllers/membership/update/updateMembership.ts
@@ -5,7 +5,7 @@ const updateMembership = async (req: Request, res: Response) => {
   try {
     const membership = req.requestedMembership;
     const project = req.requestedProject;
-    const user = await membership.getUser();
+    const user = membership.user;
     const {
       isProjectAdmin,
       isBlueprintManager,


### PR DESCRIPTION
I noticed a pattern on the new membership endpoints that contain a membershipId; We were always calling `await membership.getUser()` to retrieve user data that is sent back in the response.

Since we are always going to return this data I wanted to reduce the amount of database calls we are making, so I updated our code to eager-load a memberships user.